### PR TITLE
Add home button to purchase orders list

### DIFF
--- a/components/panels/listbicomponenteordenescompra.tsx
+++ b/components/panels/listbicomponenteordenescompra.tsx
@@ -98,7 +98,16 @@ export default function ListBiComponenteOrdenesCompra() {
   const renderOrdenesTab = () => (
     <div className="w-full">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">📋 Órdenes de Compra</h1>
+        <div className="flex items-center gap-4">
+          <h1 className="text-3xl font-bold text-gray-900">📋 Órdenes de Compra</h1>
+          <Button 
+            onClick={() => router.push("/protected")} 
+            variant="outline" 
+            className="border-gray-500 text-gray-600 hover:bg-gray-50"
+          >
+            🏠 Ir a Home
+          </Button>
+        </div>
         <Button onClick={handleCrearOrden} className="bg-blue-600 hover:bg-blue-700">
           ➕ Crear Nueva Orden
         </Button>


### PR DESCRIPTION
Add a "Go to Home" button to the purchase orders list to allow users to easily navigate back to the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-892d6633-09ad-41de-b21d-de70960a11db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-892d6633-09ad-41de-b21d-de70960a11db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

