### PR TITLE
Add articles array to order observations

### DIFF
--- a/components/lists/listaordenescompra.tsx
+++ b/components/lists/listaordenescompra.tsx
@@ -17,6 +17,13 @@ interface OrdenCompra {
   estado: string;
   total: number;
   observaciones?: string;
+  articulos?: Array<{
+    articulo_id: string;
+    articulo_nombre: string;
+    cantidad: number;
+    precio_unitario: number;
+    total: number;
+  }>;
 }
 
 export default function ListaOrdenesCompra() {
@@ -42,6 +49,7 @@ export default function ListaOrdenesCompra() {
         .order("fecha", { ascending: false });
 
       if (error) throw error;
+      console.log("🔍 Datos obtenidos:", data); // Debug para verificar que incluye artículos
       setOrdenes(data || []);
     } catch (err) {
       console.error("Error fetching ordenes:", err);
@@ -144,7 +152,7 @@ export default function ListaOrdenesCompra() {
                 </div>
               </CardHeader>
               <CardContent className="pt-0">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
                   <div>
                     <span className="font-medium text-gray-700">Dirección:</span>
                     <p className="text-gray-600">{orden.direccion}</p>
@@ -156,6 +164,27 @@ export default function ListaOrdenesCompra() {
                   <div>
                     <span className="font-medium text-gray-700">Observaciones:</span>
                     <p className="text-gray-600">{orden.observaciones || "Sin observaciones"}</p>
+                  </div>
+                  <div>
+                    <span className="font-medium text-gray-700">Artículos:</span>
+                    <div className="text-gray-600">
+                      {orden.articulos && orden.articulos.length > 0 ? (
+                        <div className="space-y-1">
+                          {orden.articulos.slice(0, 3).map((articulo, index) => (
+                            <p key={index} className="text-xs">
+                              • {articulo.articulo_nombre} (x{articulo.cantidad})
+                            </p>
+                          ))}
+                          {orden.articulos.length > 3 && (
+                            <p className="text-xs text-blue-600 font-medium">
+                              +{orden.articulos.length - 3} más...
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-xs">Sin artículos</p>
+                      )}
+                    </div>
                   </div>
                 </div>
                 <div className="flex justify-end mt-4 gap-2">

--- a/components/lists/listaordenescompra.tsx
+++ b/components/lists/listaordenescompra.tsx
@@ -173,6 +173,11 @@ export default function ListaOrdenesCompra() {
                   <div>
                     <span className="font-medium text-gray-700">Artículos:</span>
                     <div className="text-gray-600">
+                      {/* Debug temporal - mostrar todos los campos de la orden */}
+                      <div className="text-xs text-gray-500 mb-2">
+                        Debug campos: {Object.keys(orden).join(', ')}
+                      </div>
+                      
                       {orden.articulos && orden.articulos.length > 0 ? (
                         <div className="space-y-1">
                           {orden.articulos.slice(0, 3).map((articulo, index) => (
@@ -192,6 +197,12 @@ export default function ListaOrdenesCompra() {
                           <p className="text-xs text-red-500 mt-1">
                             Debug: {orden.articulos ? `Array vacío (${orden.articulos.length})` : 'Campo undefined'}
                           </p>
+                          {/* Intentar con el campo 'items' por si acaso */}
+                          {(orden as any).items && (
+                            <p className="text-xs text-blue-500 mt-1">
+                              Encontrado campo 'items': {JSON.stringify((orden as any).items).substring(0, 100)}...
+                            </p>
+                          )}
                         </div>
                       )}
                     </div>

--- a/components/lists/listaordenescompra.tsx
+++ b/components/lists/listaordenescompra.tsx
@@ -9,7 +9,8 @@ import { useRouter } from "next/navigation";
 
 interface OrdenCompra {
   id: number;
-  fecha: string;
+  fecha_creacion?: string;
+  fecha?: string;
   cuit: string;
   proveedor: string;
   direccion: string;
@@ -46,10 +47,14 @@ export default function ListaOrdenesCompra() {
       const { data, error } = await supabase
         .from("ordenes_compra")
         .select("*")
-        .order("fecha", { ascending: false });
+        .order("fecha_creacion", { ascending: false });
 
       if (error) throw error;
       console.log("🔍 Datos obtenidos:", data); // Debug para verificar que incluye artículos
+      if (data && data.length > 0) {
+        console.log("📋 Ejemplo de orden:", data[0]); // Debug estructura completa
+        console.log("🎯 Artículos en primera orden:", data[0].articulos); // Debug específico artículos
+      }
       setOrdenes(data || []);
     } catch (err) {
       console.error("Error fetching ordenes:", err);
@@ -140,7 +145,7 @@ export default function ListaOrdenesCompra() {
                       Orden #{orden.id} - {orden.proveedor}
                     </CardTitle>
                     <p className="text-sm text-gray-600 mt-1">
-                      CUIT: {orden.cuit} | Fecha: {new Date(orden.fecha).toLocaleDateString('es-AR')}
+                      CUIT: {orden.cuit} | Fecha: {new Date(orden.fecha_creacion || orden.fecha || '').toLocaleDateString('es-AR')}
                     </p>
                   </div>
                   <div className="flex items-center gap-3">
@@ -182,7 +187,12 @@ export default function ListaOrdenesCompra() {
                           )}
                         </div>
                       ) : (
-                        <p className="text-xs">Sin artículos</p>
+                        <div>
+                          <p className="text-xs">Sin artículos</p>
+                          <p className="text-xs text-red-500 mt-1">
+                            Debug: {orden.articulos ? `Array vacío (${orden.articulos.length})` : 'Campo undefined'}
+                          </p>
+                        </div>
                       )}
                     </div>
                   </div>

--- a/components/lists/listaordenescompra.tsx
+++ b/components/lists/listaordenescompra.tsx
@@ -50,11 +50,7 @@ export default function ListaOrdenesCompra() {
         .order("fecha_creacion", { ascending: false });
 
       if (error) throw error;
-      console.log("🔍 Datos obtenidos:", data); // Debug para verificar que incluye artículos
-      if (data && data.length > 0) {
-        console.log("📋 Ejemplo de orden:", data[0]); // Debug estructura completa
-        console.log("🎯 Artículos en primera orden:", data[0].articulos); // Debug específico artículos
-      }
+      console.log("🔍 Datos obtenidos:", data);
       setOrdenes(data || []);
     } catch (err) {
       console.error("Error fetching ordenes:", err);
@@ -111,7 +107,10 @@ export default function ListaOrdenesCompra() {
   const renderOrdenesTab = () => (
     <div className="w-full">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">📋 Órdenes de Compra</h1>
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">📋 Órdenes de Compra</h1>
+          <p className="text-sm text-gray-500 mt-1">Total de órdenes: {ordenes.length}</p>
+        </div>
         <Button onClick={handleCrearOrden} className="bg-blue-600 hover:bg-blue-700">
           ➕ Crear Nueva Orden
         </Button>
@@ -173,12 +172,7 @@ export default function ListaOrdenesCompra() {
                   <div>
                     <span className="font-medium text-gray-700">Artículos:</span>
                     <div className="text-gray-600">
-                      {/* Debug temporal - mostrar todos los campos de la orden */}
-                      <div className="text-xs text-gray-500 mb-2">
-                        Debug campos: {Object.keys(orden).join(', ')}
-                      </div>
-                      
-                      {orden.articulos && orden.articulos.length > 0 ? (
+                      {Array.isArray(orden.articulos) && orden.articulos.length > 0 ? (
                         <div className="space-y-1">
                           {orden.articulos.slice(0, 3).map((articulo, index) => (
                             <p key={index} className="text-xs">
@@ -192,18 +186,9 @@ export default function ListaOrdenesCompra() {
                           )}
                         </div>
                       ) : (
-                        <div>
-                          <p className="text-xs">Sin artículos</p>
-                          <p className="text-xs text-red-500 mt-1">
-                            Debug: {orden.articulos ? `Array vacío (${orden.articulos.length})` : 'Campo undefined'}
-                          </p>
-                          {/* Intentar con el campo 'items' por si acaso */}
-                          {(orden as any).items && (
-                            <p className="text-xs text-blue-500 mt-1">
-                              Encontrado campo 'items': {JSON.stringify((orden as any).items).substring(0, 100)}...
-                            </p>
-                          )}
-                        </div>
+                        <p className="text-xs text-gray-500">
+                          {!orden.articulos ? 'No hay artículos' : `Artículos: ${orden.articulos.length || 0}`}
+                        </p>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
Add the array of articles to the purchase order list to display them next to observations.

---
<a href="https://cursor.com/background-agent?bcId=bc-36b15ef7-9e5a-45ae-ab50-d88e44338564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36b15ef7-9e5a-45ae-ab50-d88e44338564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

